### PR TITLE
Adding support for flushing out buffers we hold on to

### DIFF
--- a/Sources/morsel/FragmentedMP4Writer.swift
+++ b/Sources/morsel/FragmentedMP4Writer.swift
@@ -84,8 +84,8 @@ public class FragmentedMP4Writer {
     /// - Parameters:
     ///   - sample: Sample data that should be written to the stream
     ///   - type: Flag indicating whether the sample is audio or video
-    public func append(sample: CompressedSample, type: CompressedSampleType) {
-        switch type {
+    public func append(sample: CompressedSample) {
+        switch sample.type {
         case .video: self.append(videoSample: sample)
         case .audio: self.append(audioSample: sample)
         }
@@ -126,7 +126,8 @@ public class FragmentedMP4Writer {
     
     /// Appends and end tag for now
     public func stop() {
-        self.representation.state = .done
+        self.segmenter?.flush()
+        self.representation.end()
     }
     
 }

--- a/Sources/morsel/Representation.swift
+++ b/Sources/morsel/Representation.swift
@@ -44,4 +44,8 @@ internal class Representation {
         self.playlists.append(writer)
     }
     
+    internal func end() {
+        self.state = .done
+        self.playlists.forEach { $0.update() }
+    }
 }

--- a/Sources/morsel/StreamSegmenter.swift
+++ b/Sources/morsel/StreamSegmenter.swift
@@ -193,4 +193,9 @@ final internal class StreamSegmenter {
         }
     }
     
+    internal func flush() {
+        while videoSamples.count > 0 { self.writeMOOF() }
+        self.signalNewSegment()
+    }
+    
 }

--- a/Tests/morselTests/FragmentedMP4WriterTests.swift
+++ b/Tests/morselTests/FragmentedMP4WriterTests.swift
@@ -1,10 +1,74 @@
 import XCTest
 @testable import morsel
+import grip
+
+let sps: [UInt8] = [66, 0, 30, 137, 139, 96, 80, 30, 216,
+                    8, 96, 96, 0, 187, 128, 0, 46, 224, 189,
+                    239, 131, 225, 16, 141, 192]
+
+let pps: [UInt8] = [40, 206, 31, 32]
 
 class FragmentedMP4WriterTests: XCTestCase {
-    
-    func test_that_we_can_support_multiple_playlists() {
+
+    var iFrame          = VideoSample(bytes: keyframePayload)
+    var pFrame          = VideoSample(bytes: pframePayload)
+    var videoSettings   = VideoSettings(params: [sps, pps],
+                                        dimensions: landscape,
+                                        timescale: 10)
+
+    class MockDelegate: FileWriterDelegate {
         
+        var writeExp: XCTestExpectation?
+        var updateExp: XCTestExpectation?
+        
+        var files: [URL] = []
+        
+        func wroteFile(at url: URL) {
+            writeExp?.fulfill()
+            self.files.append(url)
+        }
+
+        func updatedFile(at url: URL) {
+            updateExp?.fulfill()
+        }
+    }
+    
+    func test_that_we_flush_buffers_when_we_call_end() {
+  
+        let outdir   = URL(fileURLWithPath: NSTemporaryDirectory())
+        let delegate = MockDelegate()
+        let subject  = try? FragmentedMP4Writer(outdir,
+                                                targetDuration: 10,
+                                                streamType: .video,
+                                                delegate: delegate)
+        XCTAssertNotNil(subject)
+        
+        let playlist = Playlist(type: .hls_vod, fileName: "vod.m3u8")
+        XCTAssertNoThrow(try subject?.add(playlist: playlist))
+        
+        delegate.writeExp = self.expectation(description: "We should write a file")
+        
+        subject?.configure(settings: videoSettings)
+        XCTAssertEqual(iFrame.durationInSeconds, 0.5)
+        XCTAssertEqual(pFrame.durationInSeconds, 0.5)
+        
+        subject?.append(sample: iFrame)
+        self.wait(for: [delegate.writeExp!], timeout: 2)
+        XCTAssertEqual(1, delegate.files.count)
+
+        subject?.append(sample: pFrame)
+
+        subject?.append(sample: iFrame)
+        subject?.append(sample: pFrame)
+
+        subject?.append(sample: iFrame)
+        subject?.append(sample: pFrame)
+        
+        delegate.writeExp = self.expectation(description: "We should flush what we have")
+        subject?.stop()
+
+        self.wait(for: [delegate.writeExp!], timeout: 1)
+        XCTAssertEqual(2, delegate.files.count)
     }
     
 }


### PR DESCRIPTION
Very minimal support for flushing everything out.

Called on `stop()`